### PR TITLE
Adding admin e-mail requirement during install

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -45,6 +45,10 @@ ram.runtime = "800M"
     [install.password]
     type = "password"
 
+    [install.email]
+    type = "email"
+    example = "user@example.org"
+
 [resources]
     [resources.system_user]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -47,6 +47,8 @@ ram.runtime = "800M"
 
     [install.email]
     type = "email"
+    ask.en = "The superuser email, can be your own email"
+    ask.fr = "L'email super-utilisateur, peut être votre email"
     example = "user@example.org"
 
 [resources]

--- a/scripts/install
+++ b/scripts/install
@@ -11,9 +11,6 @@ source /usr/share/yunohost/helpers
 # INITIALIZE AND STORE SETTINGS
 #=================================================
 
-# Maybe add that as install arg ?
-email="admin@$domain"
-
 # mailman3-app database
 db_name_app=$(ynh_sanitize_dbid --db_name="${app}_app")
 db_user_app=$db_name_app
@@ -88,7 +85,7 @@ popd
 #=================================================
 ynh_script_progression --message="Creating superuser..."
 pushd /usr/share/mailman3-web
-    echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('$admin', '$email', '$password')" | python manage.py shell
+    echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('$admin', '$email', '$password')" | python3 manage.py shell
 popd
 
 #=================================================

--- a/tests.toml
+++ b/tests.toml
@@ -4,6 +4,8 @@ test_format = 1.0
 
 [default]
 
+    args.email = "package_checker@domain.tld"
+    
     exclude = ["change_url"]
 
     # -------------------------------


### PR DESCRIPTION
## Problem

- Solves #34 (as far as I can see)

## Solution

- Adding a field "e-mail" at install step, so that the variable "email" is available for the install script.
Note that I'm not a dev and consider this a dirty hack ;-)

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable) (tested by @TomRicci : https://github.com/YunoHost-Apps/mailman3_ynh/issues/34#issuecomment-1295314257)

