### PR TITLE
Update mailman.cfg to modify the DB scheme to postgresql://

### DIFF
--- a/conf/mailman.cfg
+++ b/conf/mailman.cfg
@@ -170,7 +170,7 @@ class: mailman.database.postgresql.PostgreSQLDatabase
 # 'configuration' substitutions.
 #url: sqlite:///$DATA_DIR/mailman.db
 #url: mysql+pymysql://mailman3:mmpass@localhost/mailman3?charset=utf8&use_unicode=1
-url: postgres://__DB_USER_APP__:__DB_PWD_APP__@localhost/__DB_NAME_APP__
+url: postgresql://__DB_USER_APP__:__DB_PWD_APP__@localhost/__DB_NAME_APP__
 
 debug: no
 


### PR DESCRIPTION
As seen in issue #48 the newer versions of sqlalchemy doesn't use the "postgres://" scheme anymore but expect it to be postgresql:// (see https://github.com/sqlalchemy/sqlalchemy/issues/6083#issuecomment-801478013)

I did not test the fix as a Yunohost upgrade but did change locally my /etc/mailman3/mailman.cfg file.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

